### PR TITLE
Style changes + show stage

### DIFF
--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -17,30 +17,19 @@
 import cn from 'classnames';
 import styleUtils from './utils.module.css';
 import styles from './hero.module.css';
-import { BRAND_NAME, DATE, SITE_DESCRIPTION } from '@lib/constants';
+import { BRAND_NAME, CONF_TITLE, DATE, SITE_DESCRIPTION } from '@lib/constants';
 
 export default function Hero() {
   return (
     <div className={styles.wrapper}>
-      <h2
-        className={cn(
-          styleUtils.appear,
-          styleUtils['appear-third'],
-          styleUtils['show-on-mobile'],
-          styles.description
-        )}
-      >
-        {SITE_DESCRIPTION}
-      </h2>
       <h1 className={cn(styleUtils.appear, styleUtils['appear-third'], styles.hero)}>
-        The first {BRAND_NAME}
-        <br className={styleUtils['show-on-desktop']} /> global user conference
+        {BRAND_NAME} : {CONF_TITLE}
+        <br className={styleUtils['show-on-desktop']} />
       </h1>
       <h2
         className={cn(
           styleUtils.appear,
           styleUtils['appear-third'],
-          styleUtils['show-on-tablet'],
           styles.description
         )}
       >

--- a/components/index.tsx
+++ b/components/index.tsx
@@ -51,7 +51,6 @@ export default function Conf({
             <>
               <Hero />
               <Form />
-              <LearnMore />
             </>
           ) : (
             <Ticket

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -38,7 +38,6 @@ export default function Layout({ children, className, hideNav, layoutStyles }: P
 
   return (
     <>
-      <ViewSource />
       <div className={styles.background}>
         {!hideNav && (
           <header className={cn(styles.header)}>
@@ -65,7 +64,6 @@ export default function Layout({ children, className, hideNav, layoutStyles }: P
               ))}
             </div>
             <div className={cn(styles['header-right'])}>
-              <HostedByVercel />
             </div>
           </header>
         )}

--- a/components/stage-container.js
+++ b/components/stage-container.js
@@ -22,12 +22,7 @@ import styleUtils from './utils.module.css';
 // import ScheduleSidebar from './schedule-sidebar';
 import ConfEntry from './conf-entry';
 
-type Props = {
-  stage: Stage;
-  allStages: Stage[];
-};
-
-export default function StageContainer({ stage }: Props) {
+export default function StageContainer({ stage }) {
   const { loginStatus, mutate } = useLoginStatus();
 
   return (
@@ -48,7 +43,7 @@ export default function StageContainer({ stage }: Props) {
                 <h2 className={styles.stageName}>{stage.name}</h2>
               </div>
               <a
-                href={stage.discord}
+                href={stage.chat_link}
                 target="_blank"
                 rel="noopener noreferrer"
                 className={styles.button}

--- a/lib/cms-api.js
+++ b/lib/cms-api.js
@@ -33,3 +33,7 @@ export async function getSpeakers() {
 export async function getInnovators() {
   return cmsApi.getInnovators();
 }
+
+export async function getStage() {
+  return cmsApi.getStages();
+}

--- a/lib/cms-provider/index.js
+++ b/lib/cms-provider/index.js
@@ -56,6 +56,53 @@ async function fetchCmsAPI(query) {
   return json.data;
 }
 
+export async function getStages() {
+  const data = await fetchCmsAPI(`
+    {
+      allExperiences(uid: "catalyst-event-2021", lang: "en-us") {
+        edges {
+          node {
+            body {
+              ... on ExperienceBodyStages {
+                fields {
+                  stage {
+                    ... on Stage {
+                      _meta {
+                        uid
+                      }
+                      name
+                      stream {
+                        ... on _ExternalLink {
+                          url
+                        }
+                      }
+                      chat_link {
+                        ... on _ExternalLink {
+                          url
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }  
+  `);
+
+  const reformattedData = data.allExperiences.edges[0].node.body[3].fields.map(({ stage }) => {
+    return {
+      name: stage.name,
+      stream: getLinkUrl(stage.stream),
+      chat_link: getLinkUrl(stage.chat_link)
+    }
+  });
+
+  return reformattedData;
+}
+
 export async function getSchedule() {
   const data = await fetchCmsAPI(`
     {

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -17,14 +17,21 @@
 export const SITE_URL = 'https://demo.vercel.events';
 export const SITE_ORIGIN = process.env.NEXT_PUBLIC_SITE_ORIGIN || new URL(SITE_URL).origin;
 export const TWITTER_USER_NAME = 'vercel';
-export const BRAND_NAME = 'ACME';
+export const BRAND_NAME = 'TEDxCMU';
+export const CONF_TITLE = 'Catalyst';
 export const SITE_NAME_MULTILINE = ['ACME', 'Conf'];
 export const SITE_NAME = 'ACME Conf';
 export const META_DESCRIPTION =
   'This is an open source demo that Next.js developers can clone, deploy, and fully customize for events. Created through collaboration of marketers, designers, and developers at Vercel.';
+export const SCHEDULE_DESCRIPTION =
+  'This is the tagline for the schedule page.';
+export const SPEAKERS_DESCRIPTION =
+  'This is the tagline for the speakers page.';
+export const EXPO_DESCRIPTION =
+  'This is the tagline for the expo page.';
 export const SITE_DESCRIPTION =
   'An interactive online experience by the community, free for everyone.';
-export const DATE = 'October 27, 2020';
+export const DATE = 'April 3, 2021';
 export const SHORT_DATE = 'Oct 27 - 9:00am PST';
 export const FULL_DATE = 'Oct 27th 9am Pacific Time (GMT-7)';
 export const TWEET_TEXT = META_DESCRIPTION;

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -19,10 +19,10 @@ export const SITE_ORIGIN = process.env.NEXT_PUBLIC_SITE_ORIGIN || new URL(SITE_U
 export const TWITTER_USER_NAME = 'vercel';
 export const BRAND_NAME = 'TEDxCMU';
 export const CONF_TITLE = 'Catalyst';
-export const SITE_NAME_MULTILINE = ['ACME', 'Conf'];
-export const SITE_NAME = 'ACME Conf';
+export const SITE_NAME_MULTILINE = ['TEDxCMU', 'Conf'];
+export const SITE_NAME = 'TEDxCMU Virtual Conference';
 export const META_DESCRIPTION =
-  'This is an open source demo that Next.js developers can clone, deploy, and fully customize for events. Created through collaboration of marketers, designers, and developers at Vercel.';
+  'TEDxCMU\'s first ever virtual conference. Introducing, CATALYST.';
 export const SCHEDULE_DESCRIPTION =
   'This is the tagline for the schedule page.';
 export const SPEAKERS_DESCRIPTION =
@@ -32,8 +32,8 @@ export const EXPO_DESCRIPTION =
 export const SITE_DESCRIPTION =
   'An interactive online experience by the community, free for everyone.';
 export const DATE = 'April 3, 2021';
-export const SHORT_DATE = 'Oct 27 - 9:00am PST';
-export const FULL_DATE = 'Oct 27th 9am Pacific Time (GMT-7)';
+export const SHORT_DATE = 'Apr 3rd - 9:00am PST';
+export const FULL_DATE = 'Apr 3rd 9am Pacific Time (GMT-7)';
 export const TWEET_TEXT = META_DESCRIPTION;
 export const COOKIE = 'user-id';
 

--- a/pages/expo.js
+++ b/pages/expo.js
@@ -19,19 +19,20 @@ import Header from '@components/header';
 import Layout from '@components/layout';
 import InnovatorsGrid from 'components/innovators-grid';
 
-import { META_DESCRIPTION } from '@lib/constants';
+import { EXPO_DESCRIPTION } from '@lib/constants';
 import { getInnovators } from 'lib/cms-api';
 
 export default function ExpoPage({ innovators }) {
   const meta = {
     title: 'Expo - TEDxCMU Catalyst',
-    description: META_DESCRIPTION
+    description: EXPO_DESCRIPTION
   };
 
   return (
     <Page meta={meta}>
       <Layout>
         <Header hero="Expo" description={meta.description} />
+        <p>{meta.description}</p>
         <InnovatorsGrid innovators={innovators} />
       </Layout>
     </Page>

--- a/pages/schedule.js
+++ b/pages/schedule.js
@@ -22,12 +22,12 @@ import Layout from '@components/layout';
 import Header from '@components/header';
 
 import { getSchedule } from 'lib/cms-api';
-import { META_DESCRIPTION } from '@lib/constants';
+import { SCHEDULE_DESCRIPTION } from '@lib/constants';
 
 export default function SchedulePage({ events }) {
   const meta = {
     title: 'Schedule - TEDxCMU Catalyst',
-    description: META_DESCRIPTION
+    description: SCHEDULE_DESCRIPTION
   };
 
   return (

--- a/pages/speakers.js
+++ b/pages/speakers.js
@@ -20,12 +20,12 @@ import Header from '@components/header';
 import SpeakersGrid from 'components/speakers-grid';
 
 import { getSpeakers } from 'lib/cms-api';
-import { META_DESCRIPTION } from '@lib/constants';
+import { SPEAKERS_DESCRIPTION } from '@lib/constants';
 
 export default function Speakers({ speakers }) {
   const meta = {
     title: 'Speakers - TEDxCMU Catalyst',
-    description: META_DESCRIPTION
+    description: SPEAKERS_DESCRIPTION
   };
 
   return (

--- a/pages/stage.js
+++ b/pages/stage.js
@@ -17,10 +17,11 @@
 import Page from '@components/page';
 import StageContainer from '@components/stage-container';
 import Layout from '@components/layout';
+import { getStage } from 'lib/cms-api';
 
 import { META_DESCRIPTION } from '@lib/constants';
 
-export default function StagePage({ stage, allStages }) {
+export default function StagePage({ stage }) {
   const meta = {
     title: 'Stage - TEDxCMU Catalyst',
     description: META_DESCRIPTION
@@ -33,4 +34,16 @@ export default function StagePage({ stage, allStages }) {
       </Layout>
     </Page>
   );
+}
+
+export async function getStaticProps() {
+  const stages = await getStage();
+  const stage = stages[0];
+
+  return {
+    props: {
+      stage
+    },
+    revalidate: 1
+  };
 }

--- a/styles/global.css
+++ b/styles/global.css
@@ -15,14 +15,15 @@
  */
 
 @font-face {
-  font-family: 'Inter';
+  font-family: "Inter";
   font-style: normal;
   font-weight: 100 900;
   font-display: optional;
   src: url(https://assets.vercel.com/raw/upload/v1587415301/fonts/2/inter-var-latin.woff2)
-    format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F,
-    U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+    format("woff2");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
+    U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
+    U+FEFF, U+FFFD;
 }
 
 :root {
@@ -55,7 +56,7 @@
   --secondary-color: #8a8f98;
   --sidebar: #0e0e10;
   --header-height: 72px;
-  --brand: #845ef7;
+  --brand: #ff2b06;
 }
 
 html {
@@ -64,7 +65,7 @@ html {
   height: 100%;
   box-sizing: border-box;
   touch-action: manipulation;
-  font-feature-settings: 'case' 1, 'rlig' 1, 'calt' 0;
+  font-feature-settings: "case" 1, "rlig" 1, "calt" 0;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -80,13 +81,14 @@ body {
   height: 100%;
   margin: 0;
   line-height: 1.65;
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',
-    'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto",
+    "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
+    sans-serif;
   font-size: var(--text-md);
   font-weight: 400;
   min-width: 320px;
   direction: ltr;
-  font-feature-settings: 'kern';
+  font-feature-settings: "kern";
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -101,7 +103,7 @@ body {
   background-color: #0070f3;
   color: #fff;
 }
-[role='grid']:focus {
+[role="grid"]:focus {
   outline: none;
 }
 svg {
@@ -124,7 +126,7 @@ iframe {
   border: none;
 }
 
-a[role='button'] {
+a[role="button"] {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;


### PR DESCRIPTION
Few things in this PR:
1) Updated taglines, company names, etc in constants
2) Changed the purple to red for funsies
3) Updated the schedule to be more relevant in prismic
4) Created a stage in prismic and displayed a livestream on the stage page (lofi beats for now, but will try priv livestream later).

<img width="1408" alt="Screen Shot 2021-01-08 at 12 40 24 AM" src="https://user-images.githubusercontent.com/23444739/103994067-57a8a800-514b-11eb-965c-12c654e559c4.png">
<img width="1410" alt="Screen Shot 2021-01-08 at 12 40 39 AM" src="https://user-images.githubusercontent.com/23444739/103994172-7ad35780-514b-11eb-9df8-c6aad2bbe1c9.png">
<img width="1407" alt="Screen Shot 2021-01-08 at 12 28 53 AM" src="https://user-images.githubusercontent.com/23444739/103994218-87f04680-514b-11eb-9b38-a30f62a39490.png">



